### PR TITLE
Adding ability to manage the redfish event subscriptions.

### DIFF
--- a/redfish/eventservice.go
+++ b/redfish/eventservice.go
@@ -282,6 +282,14 @@ func (eventservice *EventService) GetEventSubscription(uri string) (*EventDestin
 }
 
 // CreateEventSubscription creates the subscription using the event service.
+// destination should contain the URL of the destination for events to be sent.
+// eventTypes is a list of EventType to subscribe to.
+// httpHeaders gives the opportunity to specify any arbitrary HTTP headers
+// required for the event POST operation.
+// oem gives the opportunity to specify any OEM specific properties, it should
+// contain the vendor specific marshalled struct that goes inside the Oem session.
+// It returns the new subscription URI if the event subscription is created
+// with success or any error encountered.
 func (eventservice *EventService) CreateEventSubscription(
 	destination string,
 	eventTypes []EventType,


### PR DESCRIPTION
To manage the event subscriptions it is used the event service.

I think one main point to consider here is how the client defines the OEM specific properties during the creating event subscription (using the event service) .The idea here is that the client can define an oem parameter that is a []byte and should contain the vendor specific marshaled struct that will go inside the Oem session. I am not sure if it is the best way to do it, but this way gofish does not need to know about specific Oem properties of the vendors. 
The creation of the event subscription will return the the new subscription URI if the event subscription is created with success. 

When I get the subscription URI from the Location I am also considering the recent bug fix in the Logout to avoid the same issue "some vendor implementation returns the Location header with full URI address".  Just a thought, maybe we should think about create common function to be used anywhere when we need to get URI from the Location.