### PR TITLE
Initial work to handle Redfish registries.

### DIFF
--- a/redfish/messageregistry.go
+++ b/redfish/messageregistry.go
@@ -1,0 +1,257 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package redfish
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/stmcginnis/gofish/common"
+)
+
+// MessageRegistryMessage is a message contained in the message registry.
+type MessageRegistryMessage struct {
+	// Description is a short description of how and when to use this message.
+	Description string
+	// Message is the actual message.
+	// This property shall contain the message to display.  If a %integer is
+	// included in part of the string, it shall represent a string substitution
+	// for any MessageArgs that accompany the message, in order.
+	Message string
+	// Severity property shall contain the severity of the condition resulting in
+	// the message, as defined in the Status clause of the Redfish Specification.
+	// This property has been deprecated in favor of MessageSeverity, which ties
+	// the values to the enumerations defined for the Health property within Status.
+	Severity string
+	// MessageSeverity is the severity of the message. This property shall contain
+	// the severity of the message.
+	MessageSeverity string
+	// NumberOfArgs is the number of arguments in the message.
+	// This property shall contain the number of arguments that are substituted
+	// for the locations marked with %<integer> in the message.
+	NumberOfArgs int
+	// ParamTypes are the MessageArg types, in order, for the message.
+	ParamTypes []string
+	// Resolution is used to provide suggestions on how to resolve the situation
+	// that caused the error.
+	Resolution string
+	// Oem shall contain the OEM extensions. All values for properties that
+	// this object contains shall conform to the Redfish Specification
+	// described requirements.
+	Oem interface{}
+}
+
+// MessageRegistry schema describes all message registries.
+// It represents the properties for the message registries themselves.
+type MessageRegistry struct {
+	common.Entity
+
+	// ODataType is the odata type.
+	ODataType string `json:"@odata.type"`
+	// Description provides a description of this resource.
+	Description string
+	// RegistryPrefix is the single-word prefix that is used in forming and decoding MessageIds.
+	RegistryPrefix string
+	// RegistryVersion is the message registry version in the middle portion of a MessageId.
+	RegistryVersion string
+	// Language is the RFC5646-conformant language code for the message registry.
+	Language string
+	// OwningEntity ins the organization or company that publishes this message registry.
+	OwningEntity string
+	// Messages are the messages for the message registry.
+	Messages map[string]MessageRegistryMessage
+}
+
+// GetMessageRegistry will get a MessageRegistry instance from the Redfish service.
+func GetMessageRegistry(
+	c common.Client,
+	uri string,
+) (*MessageRegistry, error) {
+	resp, err := c.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var t MessageRegistry
+	err = json.NewDecoder(resp.Body).Decode(&t)
+	if err != nil {
+		return nil, err
+	}
+
+	return &t, nil
+}
+
+// ListReferencedMessageRegistries gets the collection of MessageRegistry.
+func ListReferencedMessageRegistries(
+	c common.Client,
+	link string,
+) ([]*MessageRegistry, error) {
+	var result []*MessageRegistry
+	links, err := common.GetCollection(c, link)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, sLink := range links.ItemLinks {
+		mrf, err := GetMessageRegistryFile(c, sLink)
+		if err != nil {
+			return nil, err
+		}
+		// get message registry from all location
+		for _, location := range mrf.Location {
+			mr, err := GetMessageRegistry(c, location.URI)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, mr)
+		}
+	}
+
+	return result, nil
+}
+
+// ListReferencedMessageRegistriesByLanguage gets the collection of MessageRegistry.
+// language is the RFC5646-conformant language code for the message registry.
+func ListReferencedMessageRegistriesByLanguage(
+	c common.Client,
+	link string,
+	language string,
+) ([]*MessageRegistry, error) {
+	language = strings.TrimSpace(language)
+	if len(language) == 0 {
+		return nil, fmt.Errorf("received empty language")
+	}
+
+	var result []*MessageRegistry
+	links, err := common.GetCollection(c, link)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, sLink := range links.ItemLinks {
+		mrf, err := GetMessageRegistryFile(c, sLink)
+		if err != nil {
+			return nil, err
+		}
+		// get message registry from all location
+		for _, location := range mrf.Location {
+			if location.Language == language {
+				mr, err := GetMessageRegistry(c, location.URI)
+				if err != nil {
+					return nil, err
+				}
+				result = append(result, mr)
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// GetMessageRegistryByLanguage gets the message registry by language.
+// registry is used to identify the correct Message Registry
+// file (MessageRegistryFile.Registry) and it shall contain the
+// Message Registry name and it major and minor versions, as defined
+// by the Redfish Specification.
+// language is the RFC5646-conformant language code for the message registry.
+func GetMessageRegistryByLanguage(
+	c common.Client,
+	link string,
+	registry string,
+	language string,
+) (*MessageRegistry, error) {
+	registry = strings.TrimSpace(registry)
+	if len(registry) == 0 {
+		return nil, fmt.Errorf("received empty registry")
+	}
+
+	language = strings.TrimSpace(language)
+	if len(language) == 0 {
+		return nil, fmt.Errorf("received empty language")
+	}
+
+	links, err := common.GetCollection(c, link)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, sLink := range links.ItemLinks {
+		s, err := GetMessageRegistryFile(c, sLink)
+		if err != nil {
+			return nil, err
+		}
+		// search for the correct registry
+		if s.Registry == registry {
+			// search for the correct location
+			for _, location := range s.Location {
+				if location.Language == language {
+					return GetMessageRegistry(c, location.URI)
+				}
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("message registry not found")
+}
+
+// GetMessageFromMessageRegistryByLanguage tries to find and get the message
+// from the informed messageID.
+// messageID is the key used to find the registry, version and message:
+// Example of messageID: Alert.1.0.LanDisconnect
+//  - The segment before the 1st period is the Registry Name (Registry Prefix): Alert
+//  - The segment between the 1st and 2nd period is the major version: 1
+//  - The segment between the 2nd and 3rd period is the minor version: 0
+//  - The segment after the 3rd period is the Message Identifier in the Registry: LanDisconnect
+// language is the RFC5646-conformant language code for the message registry.
+// Example of language: en
+func GetMessageFromMessageRegistryByLanguage(
+	c common.Client,
+	link string,
+	messageID string,
+	language string,
+) (*MessageRegistryMessage, error) {
+
+	messageID = strings.TrimSpace(messageID)
+	if len(messageID) == 0 {
+		return nil, fmt.Errorf("received empty messageID")
+	}
+
+	language = strings.TrimSpace(language)
+	if len(language) == 0 {
+		return nil, fmt.Errorf("received empty language")
+	}
+
+	// split messageID
+	messageIDSplitted := strings.Split(messageID, ".")
+
+	// validate messageID
+	if len(messageIDSplitted) != 4 {
+		return nil, fmt.Errorf("received invalid messageID %s", messageID)
+	}
+
+	// get information from the messageID
+	registryPrefix := messageIDSplitted[0]
+	registryMajorVersion := messageIDSplitted[1]
+	registryMinorVersion := messageIDSplitted[2]
+	registryMajorMinorVersion := registryMajorVersion + "." + registryMinorVersion
+	registryMessageKey := messageIDSplitted[3]
+
+	allMessageRegistryByLanguage, err := ListReferencedMessageRegistriesByLanguage(c, link, language)
+	if err != nil {
+		return nil, err
+	}
+	for _, mr := range allMessageRegistryByLanguage {
+		if mr.RegistryPrefix == registryPrefix &&
+			strings.HasPrefix(mr.RegistryVersion, registryMajorMinorVersion) {
+			if m, ok := mr.Messages[registryMessageKey]; ok {
+				return &m, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("message not found")
+}

--- a/redfish/messageregistry.go
+++ b/redfish/messageregistry.go
@@ -137,7 +137,7 @@ func ListReferencedMessageRegistriesByLanguage(
 		if err != nil {
 			return nil, err
 		}
-		// get message registry from all location
+		// get message registry by language
 		for _, location := range mrf.Location {
 			if location.Language == language {
 				mr, err := GetMessageRegistry(c, location.URI)

--- a/redfish/messageregistry_test.go
+++ b/redfish/messageregistry_test.go
@@ -1,0 +1,244 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package redfish
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+var messageRegistryBody = `{
+		"@odata.type": "#MessageRegistry.v1_2_0.MessageRegistry",
+		"Description": "This registry is an example.",
+		"Id": "MyRegistry.json",
+		"Language": "en",
+		"Messages": {
+			"FirstMessage": {
+				"Description": "Example of message with one arg.",
+				"Message": "This message has only one arg: %1",
+				"NumberOfArgs": 1,
+				"ParamTypes": [
+					"string"
+				],
+				"Resolution": "The resolution for the first message.",
+				"Severity": "OK"
+			},
+			"SecondMessage": {
+				"Description": "Example of message without args.",
+				"Message": "This message has no args.",
+				"NumberOfArgs": 0,
+				"ParamTypes": [],
+				"Resolution": "The resolution for the second message.",
+				"Severity": "Critical"
+			},
+			"ThirdMessage": {
+				"Description": "Example of message with two args.",
+				"Message": "This message has two args: %1 and %2",
+				"NumberOfArgs": 2,
+				"ParamTypes": [
+					"string",
+					"string"
+				],
+				"Resolution": "The resolution for the third message.",
+				"Severity": "Warning"
+			},
+			"MessageWithOem": {
+				"Description": "Example of message with Oem.",
+				"Message": "This message has Oem info.",
+				"NumberOfArgs": 0,
+				"Oem": {
+					"VendorName": {
+						"OemInfo1": "The Oem info 1.",
+						"OemInfoN": "The Oem info N."
+					}
+				},
+				"ParamTypes": [],
+				"Resolution": "The resolution for the message with Oem.",
+				"Severity": "Critical"
+			}
+		},
+		"Name": "MyRegistry Registry",
+		"OwningEntity": "The vendor name",
+		"RegistryPrefix": "MyRegistry",
+		"RegistryVersion": "2.2.0"
+	}`
+
+// TestMessageRegistry tests the parsing of MessageRegistry objects.
+func TestMessageRegistry(t *testing.T) {
+	var result MessageRegistry
+	err := json.NewDecoder(strings.NewReader(messageRegistryBody)).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	if result.ID != "MyRegistry.json" {
+		t.Errorf("Received invalid ID: %s", result.ID)
+	}
+
+	if result.Description != "This registry is an example." {
+		t.Errorf("Received invalid Description: %s", result.Description)
+	}
+
+	if result.Language != "en" {
+		t.Errorf("Received invalid Language: %s", result.Language)
+	}
+
+	if result.Name != "MyRegistry Registry" {
+		t.Errorf("Received invalid Name: %s", result.Name)
+	}
+
+	if result.ODataType != "#MessageRegistry.v1_2_0.MessageRegistry" {
+		t.Errorf("Received invalid ODataType: %s", result.ODataType)
+	}
+
+	if result.OwningEntity != "The vendor name" {
+		t.Errorf("Received invalid OwningEntity: %s", result.OwningEntity)
+	}
+
+	if result.RegistryPrefix != "MyRegistry" {
+		t.Errorf("Received invalid RegistryPrefix: %s", result.RegistryPrefix)
+	}
+
+	if result.RegistryVersion != "2.2.0" {
+		t.Errorf("Received invalid RegistryVersion: %s", result.RegistryVersion)
+	}
+
+	// test the messages
+
+	if len(result.Messages) != 4 {
+		t.Errorf("Received invalid number of Messages: %d", len(result.Messages))
+	}
+
+	// FirstMessage
+	messageKey := "FirstMessage"
+	if m, ok := result.Messages[messageKey]; ok {
+		if m.Description != "Example of message with one arg." {
+			t.Errorf("Received invalid Description: %s for the messageKey: %s", m.Description, messageKey)
+		}
+		if m.Message != "This message has only one arg: %1" {
+			t.Errorf("Received invalid Message: %s for the messageKey: %s", m.Message, messageKey)
+		}
+		if m.NumberOfArgs != 1 {
+			t.Errorf("Received invalid NumberOfArgs: %d for the messageKey: %s", m.NumberOfArgs, messageKey)
+		}
+		if m.ParamTypes[0] != "string" {
+			t.Errorf("Received invalid ParamTypes: %s for the messageKey: %s", m.ParamTypes[0], messageKey)
+		}
+		if m.Resolution != "The resolution for the first message." {
+			t.Errorf("Received invalid Resolution: %s for the messageKey: %s", m.Resolution, messageKey)
+		}
+		if m.Severity != "OK" {
+			t.Errorf("Received invalid Severity: %s for the messageKey: %s", m.Severity, messageKey)
+		}
+	} else {
+		t.Errorf("MessageKey %s not found.", messageKey)
+	}
+
+	// SecondMessage
+	messageKey = "SecondMessage"
+	if m, ok := result.Messages[messageKey]; ok {
+		if m.Description != "Example of message without args." {
+			t.Errorf("Received invalid Description: %s for the messageKey: %s", m.Description, messageKey)
+		}
+		if m.Message != "This message has no args." {
+			t.Errorf("Received invalid Message: %s for the messageKey: %s", m.Message, messageKey)
+		}
+		if m.NumberOfArgs != 0 {
+			t.Errorf("Received invalid NumberOfArgs: %d for the messageKey: %s", m.NumberOfArgs, messageKey)
+		}
+		if len(m.ParamTypes) > 0 {
+			t.Errorf("Received invalid ParamTypes: %v for the messageKey: %s", m.ParamTypes, messageKey)
+		}
+		if m.Resolution != "The resolution for the second message." {
+			t.Errorf("Received invalid Resolution: %s for the messageKey: %s", m.Resolution, messageKey)
+		}
+		if m.Severity != "Critical" {
+			t.Errorf("Received invalid Severity: %s for the messageKey: %s", m.Severity, messageKey)
+		}
+	} else {
+		t.Errorf("MessageKey %s not found.", messageKey)
+	}
+
+	// ThirdMessage
+	messageKey = "ThirdMessage"
+	if m, ok := result.Messages[messageKey]; ok {
+		if m.Description != "Example of message with two args." {
+			t.Errorf("Received invalid Description: %s for the messageKey: %s", m.Description, messageKey)
+		}
+		if m.Message != "This message has two args: %1 and %2" {
+			t.Errorf("Received invalid Message: %s for the messageKey: %s", m.Message, messageKey)
+		}
+		if m.NumberOfArgs != 2 {
+			t.Errorf("Received invalid NumberOfArgs: %d for the messageKey: %s", m.NumberOfArgs, messageKey)
+		}
+		if m.ParamTypes[0] != "string" {
+			t.Errorf("Received invalid ParamTypes[0]: %s for the messageKey: %s", m.ParamTypes[0], messageKey)
+		}
+		if m.ParamTypes[1] != "string" {
+			t.Errorf("Received invalid ParamTypes[1]: %s for the messageKey: %s", m.ParamTypes[1], messageKey)
+		}
+		if m.Resolution != "The resolution for the third message." {
+			t.Errorf("Received invalid Resolution: %s for the messageKey: %s", m.Resolution, messageKey)
+		}
+		if m.Severity != "Warning" {
+			t.Errorf("Received invalid Severity: %s for the messageKey: %s", m.Severity, messageKey)
+		}
+	} else {
+		t.Errorf("MessageKey %s not found.", messageKey)
+	}
+
+	// MessageWithOem
+	messageKey = "MessageWithOem"
+	if m, ok := result.Messages[messageKey]; ok {
+		if m.Description != "Example of message with Oem." {
+			t.Errorf("Received invalid Description: %s for the messageKey: %s", m.Description, messageKey)
+		}
+		if m.Message != "This message has Oem info." {
+			t.Errorf("Received invalid Message: %s for the messageKey: %s", m.Message, messageKey)
+		}
+		if m.NumberOfArgs != 0 {
+			t.Errorf("Received invalid NumberOfArgs: %d for the messageKey: %s", m.NumberOfArgs, messageKey)
+		}
+		if len(m.ParamTypes) > 0 {
+			t.Errorf("Received invalid ParamTypes: %v for the messageKey: %s", m.ParamTypes, messageKey)
+		}
+		if m.Resolution != "The resolution for the message with Oem." {
+			t.Errorf("Received invalid Resolution: %s for the messageKey: %s", m.Resolution, messageKey)
+		}
+		if m.Severity != "Critical" {
+			t.Errorf("Received invalid Severity: %s for the messageKey: %s", m.Severity, messageKey)
+		}
+
+		// test oem
+		switch oem := m.Oem.(type) {
+		case map[string]interface{}:
+			for vendor, values := range oem {
+				if vendor != "VendorName" {
+					t.Errorf("Received invalid Oem vendor: %s for the messageKey: %s", vendor, messageKey)
+				}
+				switch val := values.(type) {
+				case map[string]interface{}:
+					for k, v := range val {
+						if k != "OemInfo1" && k != "OemInfoN" {
+							t.Errorf("Received invalid Oem key %s for vendor: %s for the messageKey: %s", k, vendor, messageKey)
+						}
+						if k == "OemInfo1" && v != "The Oem info 1." {
+							t.Errorf("Received invalid OemInfo1: %s for the messageKey: %s", v, messageKey)
+						}
+						if v == "OemInfoN" && v != "The Oem info N." {
+							t.Errorf("Received invalid OemInfoN: %s for the messageKey: %s", v, messageKey)
+						}
+					}
+				}
+			}
+		default:
+			t.Errorf("Received invalid Oem for the messageKey: %s", messageKey)
+		}
+	} else {
+		t.Errorf("MessageKey %s not found.", messageKey)
+	}
+}

--- a/redfish/messageregistryfile.go
+++ b/redfish/messageregistryfile.go
@@ -1,0 +1,81 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package redfish
+
+import (
+	"encoding/json"
+
+	"github.com/stmcginnis/gofish/common"
+)
+
+// MessageRegistryFileLocation is a location
+// information for the Message Registry file.
+type MessageRegistryFileLocation struct {
+	Language string `json:"Language"`
+	URI      string `json:"Uri"`
+}
+
+// MessageRegistryFile describes the Message Registry file locator Resource.
+type MessageRegistryFile struct {
+	common.Entity
+
+	// ODataContext is the odata context.
+	ODataContext string `json:"@odata.context"`
+	// ODataType is the odata type.
+	ODataType string `json:"@odata.type"`
+	// Description provides a description of this resource.
+	Description string
+	// Languages is the RFC5646-conformant language codes for the
+	// available Message Registries.
+	Languages []string
+	// Location is the location information for this Message Registry file.
+	Location []MessageRegistryFileLocation
+	// Registry shall contain the Message Registry name and it major and
+	// minor versions, as defined by the Redfish Specification.
+	Registry string
+}
+
+// GetMessageRegistryFile will get a MessageRegistryFile
+// instance from the Redfish service.
+func GetMessageRegistryFile(
+	c common.Client,
+	uri string,
+) (*MessageRegistryFile, error) {
+	resp, err := c.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var t MessageRegistryFile
+	err = json.NewDecoder(resp.Body).Decode(&t)
+	if err != nil {
+		return nil, err
+	}
+
+	return &t, nil
+}
+
+// ListReferencedMessageRegistryFiles gets the collection of MessageRegistryFile.
+func ListReferencedMessageRegistryFiles(
+	c common.Client,
+	link string,
+) ([]*MessageRegistryFile, error) {
+	var result []*MessageRegistryFile
+	links, err := common.GetCollection(c, link)
+	if err != nil {
+		return result, err
+	}
+
+	for _, sLink := range links.ItemLinks {
+		s, err := GetMessageRegistryFile(c, sLink)
+		if err != nil {
+			return result, err
+		}
+		result = append(result, s)
+	}
+
+	return result, nil
+}

--- a/redfish/messageregistryfile_test.go
+++ b/redfish/messageregistryfile_test.go
@@ -1,0 +1,79 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package redfish
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+var messageRegistryFileBody = `{
+		"@odata.context": "/redfish/v1/$metadata#MessageRegistryFile.MessageRegistryFile",
+		"@odata.id": "/redfish/v1/Registries/MyRegistry",
+		"@odata.type": "#MessageRegistryFile.v1_0_4.MessageRegistryFile",
+		"Id": "MyRegistry",
+		"Description": "Registry Definition File for MyRegistry",
+		"Languages": [
+			"en"
+		],
+		"Location": [
+			{
+				"Language": "en",
+				"Uri": "/redfish/v1/RegistryStore/registries/en/MyRegistry.json"
+			}
+		],
+		"Name": "MyRegistry Message Registry File",
+		"Registry": "MyRegistry.2.2.0"
+	}`
+
+// TestMessageRegistryFile tests the parsing of MessageRegistryFile objects.
+func TestMessageRegistryFile(t *testing.T) {
+	var result MessageRegistryFile
+	err := json.NewDecoder(strings.NewReader(messageRegistryFileBody)).Decode(&result)
+
+	if err != nil {
+		t.Errorf("Error decoding JSON: %s", err)
+	}
+
+	if result.Registry != "MyRegistry.2.2.0" {
+		t.Errorf("Received invalid Registry: %s", result.Registry)
+	}
+
+	if result.ODataContext != "/redfish/v1/$metadata#MessageRegistryFile.MessageRegistryFile" {
+		t.Errorf("Received invalid ODataContext: %s", result.ODataContext)
+	}
+
+	if result.ODataID != "/redfish/v1/Registries/MyRegistry" {
+		t.Errorf("Received invalid ODataID: %s", result.ODataID)
+	}
+
+	if result.ODataType != "#MessageRegistryFile.v1_0_4.MessageRegistryFile" {
+		t.Errorf("Received invalid ODataType: %s", result.ODataType)
+	}
+	if result.ID != "MyRegistry" {
+		t.Errorf("Received invalid ID: %s", result.ID)
+	}
+
+	if result.Description != "Registry Definition File for MyRegistry" {
+		t.Errorf("Received invalid Description: %s", result.Description)
+	}
+
+	if result.Languages[0] != "en" {
+		t.Errorf("Received invalid Languages: %s", result.Languages[0])
+	}
+
+	if result.Name != "MyRegistry Message Registry File" {
+		t.Errorf("Received invalid Name: %s", result.Name)
+	}
+
+	if result.Location[0].Language != "en" {
+		t.Errorf("Received invalid Location[0].Language: %s", result.Location[0].Language)
+	}
+
+	if result.Location[0].URI != "/redfish/v1/RegistryStore/registries/en/MyRegistry.json" {
+		t.Errorf("Received invalid Location[0].Uri: %s", result.Location[0].URI)
+	}
+}

--- a/serviceroot.go
+++ b/serviceroot.go
@@ -275,6 +275,42 @@ func (serviceroot *Service) EventService() (*redfish.EventService, error) {
 	return redfish.GetEventService(serviceroot.Client, serviceroot.eventService)
 }
 
+// Registries gets the Redfish Registries
+func (serviceroot *Service) Registries() ([]*redfish.MessageRegistryFile, error) {
+	return redfish.ListReferencedMessageRegistryFiles(serviceroot.Client, serviceroot.registries)
+}
+
+// MessageRegistries gets all the available message registries in all languages
+func (serviceroot *Service) MessageRegistries() ([]*redfish.MessageRegistry, error) {
+	return redfish.ListReferencedMessageRegistries(serviceroot.Client, serviceroot.registries)
+}
+
+// MessageRegistriesByLanguage gets the message registries by language.
+// language is the RFC5646-conformant language code for the message registry, for example: "en".
+func (serviceroot *Service) MessageRegistriesByLanguage(language string) ([]*redfish.MessageRegistry, error) {
+	return redfish.ListReferencedMessageRegistriesByLanguage(serviceroot.Client, serviceroot.registries, language)
+}
+
+// MessageRegistryByLanguage gets a specific message registry by language.
+// registry is used to identify the correct Message Registry file and it shall
+// contain the Message Registry name and it major and minor versions, as defined
+// by the Redfish Specification, for example: "Alert.1.0.0".
+// language is the RFC5646-conformant language code for the message registry, for example: "en".
+func (serviceroot *Service) MessageRegistryByLanguage(registry string, language string) (*redfish.MessageRegistry, error) {
+	return redfish.GetMessageRegistryByLanguage(serviceroot.Client, serviceroot.registries, registry, language)
+}
+
+// MessageByLanguage tries to find and get the message in the correct language from the informed messageID.
+// messageID is the key used to find the registry, version and message, for example: "Alert.1.0.LanDisconnect"
+//  - The segment before the 1st period is the Registry Name (Registry Prefix): Alert
+//  - The segment between the 1st and 2nd period is the major version: 1
+//  - The segment between the 2nd and 3rd period is the minor version: 0
+//  - The segment after the 3rd period is the Message Identifier in the Registry: LanDisconnect
+// language is the RFC5646-conformant language code for the message registry, for example: "en".
+func (serviceroot *Service) MessageByLanguage(messageID string, language string) (*redfish.MessageRegistryMessage, error) {
+	return redfish.GetMessageFromMessageRegistryByLanguage(serviceroot.Client, serviceroot.registries, messageID, language)
+}
+
 // Systems get the system instances from the service
 func (serviceroot *Service) Systems() ([]*redfish.ComputerSystem, error) {
 	return redfish.ListReferencedComputerSystems(serviceroot.Client, serviceroot.systems)


### PR DESCRIPTION
This is a proposal of initial work to handle Redfish registries.

It adds 5 new functions in service root:

1) Registries gets the Redfish Registries
2) MessageRegistries gets all the available message registries in all languages
3) MessageRegistriesByLanguage gets the message registries by language.
4) MessageRegistryByLanguage gets a specific message registry by language.
5) MessageByLanguage tries to find and get the message in the correct language from the informed messageID.

These new functions can be useful in a scenario whera an application creates event subscriptions and receive events where in the event we have the messageId and the application should discover the details about the event message, like the message, number of args, and others from the available Redfish Registries considering the desired language (useful for internacionalization of applications). More information can be found here: https://www.dmtf.org/sites/default/files/Redfish%20School%20-%20Events.pdf

I was also thinking about add another function similar to the new function MessageByLanguage  that also would receive the message arguments and return a final processed message, but after some consideration, I think It should not be a responsability for the library.

Created unit test files for all new files.

Performed some tests with all new functions using real Redfish server and Gofish returned the correct objects/results.

Please, let me know if it looks good and if you have any suggestions of improvements.