### PR TITLE
Changes to send the context to the HTTP request.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -5,10 +5,13 @@
 package gofish
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stmcginnis/gofish/common"
 )
@@ -86,5 +89,79 @@ func TestErrorNon400(t *testing.T) {
 	}
 	if expectErrorStatus404 != err.Error() {
 		t.Errorf("Expect:\n%s\nGot:\n%s", expectErrorStatus404, err.Error())
+	}
+}
+
+// TestConnectContextTimeout
+func TestConnectContextTimeout(t *testing.T) {
+
+	// ctx will timeout after 0.1 seconds
+	ctx, cancel := context.WithTimeout(
+		context.Background(),
+		100*time.Millisecond)
+	defer cancel()
+
+	_, err := ConnectContext(
+		ctx,
+		ClientConfig{
+			Endpoint: "https://testContextTimeout.com",
+		})
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Error("Context should timeout")
+	}
+}
+
+// TestConnectContextCancel
+func TestConnectContextCancel(t *testing.T) {
+
+	// ctx will be cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := ConnectContext(
+		ctx,
+		ClientConfig{
+			Endpoint: "https://testContextCancel.com",
+		})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Error("Context should be cancelled")
+	}
+}
+
+// TestConnectDefaultContextTimeout
+func TestConnectDefaultContextTimeout(t *testing.T) {
+
+	// ctx will timeout after 0.1 seconds
+	ctx, cancel := context.WithTimeout(
+		context.Background(),
+		100*time.Millisecond)
+	defer cancel()
+
+	_, err := ConnectDefaultContext(
+		ctx,
+		"https://testContextTimeout.com",
+	)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Error("Context should timeout")
+	}
+}
+
+// TestConnectDefaultContextCancel
+func TestConnectDefaultContextCancel(t *testing.T) {
+
+	// ctx will be cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := ConnectDefaultContext(
+		ctx,
+		"https://testContextCancel.com",
+	)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Error("Context should be cancelled")
 	}
 }


### PR DESCRIPTION
This proposal adds 2 new functions to do the connection with context:

ConnectContext - The same as Connect, but sets the ctx.
ConnectDefaultContext - The same as ConnectDefault, but sets the ctx.

Because we already have some authentication code inside Connect, the new ConnectContext is not able to reuse Connect with the correct context. So, actually it was required some changes in Connect and ConnectDefault to avoid too much code duplication. 

The context is defined in the client struct to avoid a lot of function/method signature modifications. It is not the preferred Golang idiom to send the context through the functions, but it is still ok in my opinion and it seems other libs do the same approach (probably to avoid to many modifications as would be required here). This could be an initial approach to send the context and maybe in the future we could rework to remove the context from the client struct.

Also, changed the way the request is created in order to pass the context, starting using http.NewRequestWithContext.

Performed some tests with ConnectContext with real Redfish server and Gofish returned the correct error when the context timeout. Also, tested the normal Connect function with real Redfish server and it kept working as expected.

Added unit tests to cover context timeout and context cancellation.

Please, let me know if it looks good and if you have any suggestions of improvements.

